### PR TITLE
use roundeven instead of roundnear

### DIFF
--- a/lib/Finance/Contract.pm
+++ b/lib/Finance/Contract.pm
@@ -68,7 +68,7 @@ use List::Util qw(min max first);
 use Scalar::Util qw(looks_like_number);
 use Math::Util::CalculatedValue::Validatable;
 use Date::Utility;
-use Format::Util::Numbers qw(roundnear);
+use Format::Util::Numbers qw(roundeven);
 use POSIX qw( floor );
 use Time::Duration::Concise;
 
@@ -773,7 +773,7 @@ sub _barrier_for_shortcode_string {
     my ($self, $string) = @_;
 
     return $string if $self->supplied_barrier_type eq 'relative';
-    return 'S' . roundnear(1, $string / $self->pip_size) . 'P' if $self->supplied_barrier_type eq 'difference';
+    return 'S' . roundeven(1, $string / $self->pip_size) . 'P' if $self->supplied_barrier_type eq 'difference';
 
     $string = $self->_pipsized_value($string);
     if ($self->bet_type !~ /^DIGIT/ && $self->absolute_barrier_multiplier) {
@@ -783,7 +783,7 @@ sub _barrier_for_shortcode_string {
     }
 
     # Make sure it's an integer
-    $string = roundnear(1, $string);
+    $string = roundeven(1, $string);
 
     return $string;
 }

--- a/t/for_shortcode_string.t
+++ b/t/for_shortcode_string.t
@@ -6,34 +6,36 @@ use Test::More;
 use Finance::Contract;
 
 my $params = {
-    bet_type=>'test',
-    currency=>'USD',
-    supplied_barrier_type=>'relative',
-    pip_size=>0.001,
+    bet_type              => 'test',
+    currency              => 'USD',
+    supplied_barrier_type => 'relative',
+    pip_size              => 0.001,
 };
 
-my $obj = new_ok( 'Finance::Contract', [$params] );
-cmp_ok $obj->_barrier_for_shortcode_string('S20'),'eq', 'S20', 'A relative barrier wont be changed if it is not a number';
-cmp_ok $obj->_barrier_for_shortcode_string('20'),'eq', '20', 'A relative barrier wont be changed if it is a number';
+my $obj = new_ok('Finance::Contract', [$params]);
+cmp_ok $obj->_barrier_for_shortcode_string('S20'), 'eq', 'S20', 'A relative barrier wont be changed if it is not a number';
+cmp_ok $obj->_barrier_for_shortcode_string('20'),  'eq', '20',  'A relative barrier wont be changed if it is a number';
 
 $params->{supplied_barrier_type} = 'absolute';
-$obj = new_ok( 'Finance::Contract', [$params] );
-cmp_ok $obj->_barrier_for_shortcode_string('20.20'),'eq', '20', 'An absolute barrier will be rounded to an interger if absolute_barrier_multiplier=0 ';
+$obj = new_ok('Finance::Contract', [$params]);
+cmp_ok $obj->_barrier_for_shortcode_string('20.20'), 'eq', '20',
+    'An absolute barrier will be rounded to an interger if absolute_barrier_multiplier=0 ';
 $params->{absolute_barrier_multiplier} = 1;
-$obj = new_ok( 'Finance::Contract', [$params] );
-cmp_ok $obj->_barrier_for_shortcode_string('0.12'),'eq', '120000', 'A absolute barrier will be multiplied in 1e6 if absolute_barrier_multiplier=1';
+$obj = new_ok('Finance::Contract', [$params]);
+cmp_ok $obj->_barrier_for_shortcode_string('0.12'), 'eq', '120000', 'A absolute barrier will be multiplied in 1e6 if absolute_barrier_multiplier=1';
 
 $params->{bet_type} = 'DIGITMATCH';
-$obj = new_ok( 'Finance::Contract', [$params] );
-cmp_ok $obj->_barrier_for_shortcode_string('1'),'eq', '1',  'Even if absolute_barrier_multiplier is set there wont be any multiplication for ^DIGIT.*';
+$obj = new_ok('Finance::Contract', [$params]);
+cmp_ok $obj->_barrier_for_shortcode_string('1'), 'eq', '1',
+    'Even if absolute_barrier_multiplier is set there wont be any multiplication for ^DIGIT.*';
 
-$params->{bet_type} = 'test';
+$params->{bet_type}              = 'test';
 $params->{supplied_barrier_type} = 'difference';
-$obj = new_ok( 'Finance::Contract', [$params] );
-cmp_ok $obj->_barrier_for_shortcode_string('+0.12'),'eq', 'S120P', 'A differnce barrier will manipulated to correct format depending on pipsize';
-cmp_ok $obj->_barrier_for_shortcode_string('-0.12'),'eq', 'S-120P', 'A differnce barrier will manipulated to correct format depending on pipsize';
-cmp_ok $obj->_barrier_for_shortcode_string('-0'),'eq', 'S0P', 'A differnce barrier that is -0 will be manipulated to correct format';
-cmp_ok $obj->_barrier_for_shortcode_string('+0'),'eq', 'S0P', 'A differnce barrier that is +0 will be  manipulated to correct format';
-cmp_ok $obj->_barrier_for_shortcode_string('0'),'eq', 'S0P',  'A differnce barrier that is  0 will be  manipulated to correct format';
+$obj = new_ok('Finance::Contract', [$params]);
+cmp_ok $obj->_barrier_for_shortcode_string('+0.12'), 'eq', 'S120P',  'A differnce barrier will manipulated to correct format depending on pipsize';
+cmp_ok $obj->_barrier_for_shortcode_string('-0.12'), 'eq', 'S-120P', 'A differnce barrier will manipulated to correct format depending on pipsize';
+cmp_ok $obj->_barrier_for_shortcode_string('-0'),    'eq', 'S0P',    'A differnce barrier that is -0 will be manipulated to correct format';
+cmp_ok $obj->_barrier_for_shortcode_string('+0'),    'eq', 'S0P',    'A differnce barrier that is +0 will be  manipulated to correct format';
+cmp_ok $obj->_barrier_for_shortcode_string('0'),     'eq', 'S0P',    'A differnce barrier that is  0 will be  manipulated to correct format';
 
 done_testing;


### PR DESCRIPTION
`roundnear` for small numbers does round away from zero and for numbers with more significant digits it's sort-of random

```
perl -MFormat::Util::Numbers=roundnear -le 'print roundnear 0.01, $_ for (@ARGV)' 1.005 1.015 1.025 1.035 72456245.005 72456245.015 72456245.025 72456245.035                                                                                                                                
1.01
1.02
1.03
1.04
72456245
72456245.01
72456245.03
72456245.03
```

where as BigFloat is consistent, so `roundeven` will use BigFloat

```
perl -MMath::BigFloat -le 'print Math::BigFloat->new($_)->bfround(-2) for (@ARGV)' 1.005 1.015 1.025 1.035 72456245.005 72456245.015 72456245.025 72456245.035                                                                                                                               
1.00
1.02
1.02
1.04
72456245.00
72456245.02
72456245.02
72456245.04
```