### PR TITLE
 junbon/increase_commission

### DIFF
--- a/lib/Finance/Contract.pm
+++ b/lib/Finance/Contract.pm
@@ -709,9 +709,21 @@ sub _build_timeinyears {
 sub _build_timeindays {
     my $self = shift;
 
-    my $atid = $self->get_time_to_expiry({
-            from => $self->effective_start,
-        })->days;
+    my $time_to_expiry = $self->get_time_to_expiry({
+        from => $self->effective_start,
+    });
+
+    # Since we have fixed feed generation frequency for volatility indices, we will need to adjust the contract duration
+    # to the actual number of ticks through the contract duration to prevent under-pricing ITM contracts. But we are only adjusting
+    # for contracts less than 5 minutes.
+    if ($self->market->name eq 'volidx' and not($self->is_atm_bet and $self->for_sale) and $time_to_expiry->minutes < 5) {
+        my $date_start_adjustment  = $self->date_start->epoch % 2  ? 1 : 2;
+        my $date_expiry_adjustment = $self->date_expiry->epoch % 2 ? 1 : 0;
+        my $actual_duration =
+            $self->date_expiry->minus_time_interval($date_expiry_adjustment)->epoch -
+            $self->date_start->plus_time_interval($date_start_adjustment)->epoch;
+        $time_to_expiry = Time::Duration::Concise->new(interval => $actual_duration);
+    }
 
     my $tid = Math::Util::CalculatedValue::Validatable->new({
         name        => 'time_in_days',
@@ -719,7 +731,7 @@ sub _build_timeindays {
         set_by      => 'Finance::Contract',
         minimum     => 0.000001,
         maximum     => 730,
-        base_amount => $atid,
+        base_amount => $time_to_expiry->days,
     });
 
     return $tid;

--- a/lib/Finance/Contract.pm
+++ b/lib/Finance/Contract.pm
@@ -716,7 +716,7 @@ sub _build_timeindays {
     # Since we have fixed feed generation frequency for volatility indices, we will need to adjust the contract duration
     # to the actual number of ticks through the contract duration to prevent under-pricing ITM contracts. But we are only adjusting
     # for contracts less than 5 minutes.
-    if ($self->market->name eq 'volidx' and not($self->is_atm_bet and $self->for_sale) and $time_to_expiry->minutes < 5) {
+    if ($self->market->name eq 'volidx' and not($self->is_atm_bet or $self->for_sale) and $time_to_expiry->minutes < 5) {
         my $date_start_adjustment  = $self->date_start->epoch % 2  ? 1 : 2;
         my $date_expiry_adjustment = $self->date_expiry->epoch % 2 ? 1 : 0;
         my $actual_duration =


### PR DESCRIPTION
adjust contract duration to reflect the number tick involved in a less than 5-minute non ATM volatility indices contract.

We are getting hit on ITM contracts because we have a fixed 2-second per
tick on volatility indices.