### PR TITLE
kelvin/high_lows

### DIFF
--- a/lib/Finance/Contract.pm
+++ b/lib/Finance/Contract.pm
@@ -505,6 +505,7 @@ our $BARRIER_CATEGORIES = {
     digits       => ['non_financial'],
     asian        => ['asian'],
     lookback     => ['lookback'],
+    highlowticks => ['american'],
 };
 
 =head2 barrier_category

--- a/share/contract_categories.yml
+++ b/share/contract_categories.yml
@@ -72,6 +72,15 @@ asian:
     available_types:
       - ASIANU
       - ASIAND
+highlowticks:
+    display_order : 7
+    display_name: "High/Low Ticks"
+    supported_expiries:
+      - tick
+    explanation: "Predict which tick is the highest/lowest at expiration."
+    available_types:
+      - TICKHIGH
+      - TICKLOW      
 vanilla:
     offer: 0
     display_order: 0

--- a/share/contract_categories.yml
+++ b/share/contract_categories.yml
@@ -78,6 +78,7 @@ highlowticks:
     supported_expiries:
       - tick
     explanation: "Predict which tick is the highest/lowest at expiration."
+    is_path_dependent: 1
     available_types:
       - TICKHIGH
       - TICKLOW      

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -8,6 +8,7 @@ ASIAND:
   payouttime: end
   pricing_code: PUT
   sentiment: down
+  has_user_defined_barrier: 0
 ASIANU:
   id: 230
   category: asian
@@ -17,6 +18,7 @@ ASIANU:
   payouttime: end
   pricing_code: CALL
   sentiment: up
+  has_user_defined_barrier: 0
 CALL:
   id: 10
   category: callput

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -55,26 +55,26 @@ DIGITDIFF:
   pricing_code: DIGITDIFF
   sentiment: differ
   base_commission: 0.01
-DIGITHIGH:
+TICKHIGH:
   id: 230
-  category: digits
-  display_name: high
-  other_side_code: DIGITLOW
+  category: highlowticks
+  display_name: high-tick
+  other_side_code: TICKLOW
   payout_type: binary
   payouttime: end
-  pricing_code: DIGITHIGH
+  pricing_code: TICKHIGH
   sentiment: high
-  base_commission: 0.01
-DIGITLOW:
+  base_commission: 0.015
+TICKLOW:
   id: 240
-  category: digits
-  display_name: low
-  other_side_code: DIGITHIGH
+  category: highlowticks
+  display_name: low-tick
+  other_side_code: TICKHIGH
   payout_type: binary
   payouttime: end
-  pricing_code: DIGITLOW
+  pricing_code: TICKLOW
   sentiment: low
-  base_commission: 0.01  
+  base_commission: 0.015  
 DIGITODD:
   id: 250
   category: digits

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -99,7 +99,6 @@ TICKHIGH:
   id: 230
   category: highlowticks
   display_name: high-tick
-  other_side_code: TICKLOW
   payout_type: binary
   payouttime: end
   pricing_code: TICKHIGH
@@ -109,7 +108,6 @@ TICKLOW:
   id: 240
   category: highlowticks
   display_name: low-tick
-  other_side_code: TICKHIGH
   payout_type: binary
   payouttime: end
   pricing_code: TICKLOW

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -95,33 +95,6 @@ DIGITUNDER:
   pricing_code: DIGITUNDER
   sentiment: under
   base_commission: 0.01
-TICKHIGH:
-  id: 230
-  category: highlowticks
-  display_name: high-tick
-  payout_type: binary
-  payouttime: end
-  pricing_code: TICKHIGH
-  sentiment: high
-  base_commission: 0.015
-TICKLOW:
-  id: 240
-  category: highlowticks
-  display_name: low-tick
-  payout_type: binary
-  payouttime: end
-  pricing_code: TICKLOW
-  sentiment: low
-  base_commission: 0.015  
-EXPIRYMISS:
-  id: 180
-  category: endsinout
-  display_name: Ends Outside
-  other_side_code: EXPIRYRANGE
-  payout_type: binary
-  payouttime: end
-  pricing_code: EXPIRYMISS
-  sentiment: high_vol
 EXPIRYMISSE:
   id: 310
   category: endsinout
@@ -202,6 +175,33 @@ UPORDOWN:
   payout_type: binary
   payouttime: hit
   pricing_code: UPORDOWN
+  sentiment: high_vol
+TICKHIGH:
+  id: 400
+  category: highlowticks
+  display_name: high-tick
+  payout_type: binary
+  payouttime: end
+  pricing_code: TICKHIGH
+  sentiment: high
+  base_commission: 0.015
+TICKLOW:
+  id: 410
+  category: highlowticks
+  display_name: low-tick
+  payout_type: binary
+  payouttime: end
+  pricing_code: TICKLOW
+  sentiment: low
+  base_commission: 0.015  
+EXPIRYMISS:
+  id: 180
+  category: endsinout
+  display_name: Ends Outside
+  other_side_code: EXPIRYRANGE
+  payout_type: binary
+  payouttime: end
+  pricing_code: EXPIRYMISS
   sentiment: high_vol
 VANILLA_CALL:
   category: vanilla

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -179,7 +179,7 @@ UPORDOWN:
 TICKHIGH:
   id: 400
   category: highlowticks
-  display_name: High-tick
+  display_name: High Tick
   payout_type: binary
   payouttime: end
   pricing_code: TICKHIGH
@@ -188,7 +188,7 @@ TICKHIGH:
 TICKLOW:
   id: 410
   category: highlowticks
-  display_name: Low-tick
+  display_name: Low Tick
   payout_type: binary
   payouttime: end
   pricing_code: TICKLOW

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -35,6 +35,16 @@ CALLE:
   payouttime: end
   pricing_code: CALL
   sentiment: up
+DIGITMATCH:
+  id: 210
+  category: digits
+  display_name: matches
+  other_side_code: DIGITDIFF
+  payout_type: binary
+  payouttime: end
+  pricing_code: DIGITMATCH
+  sentiment: match
+  base_commission: 0.01  
 DIGITDIFF:
   id: 220
   category: digits
@@ -45,26 +55,26 @@ DIGITDIFF:
   pricing_code: DIGITDIFF
   sentiment: differ
   base_commission: 0.01
-DIGITEVEN:
-  id: 260
+DIGITHIGH:
+  id: 230
   category: digits
-  display_name: even
-  other_side_code: DIGITODD
+  display_name: high
+  other_side_code: DIGITLOW
   payout_type: binary
   payouttime: end
-  pricing_code: DIGITEVEN
-  sentiment: even
+  pricing_code: DIGITHIGH
+  sentiment: high
   base_commission: 0.01
-DIGITMATCH:
-  id: 210
+DIGITLOW:
+  id: 240
   category: digits
-  display_name: matches
-  other_side_code: DIGITDIFF
+  display_name: low
+  other_side_code: DIGITHIGH
   payout_type: binary
   payouttime: end
-  pricing_code: DIGITMATCH
-  sentiment: match
-  base_commission: 0.01
+  pricing_code: DIGITLOW
+  sentiment: low
+  base_commission: 0.01  
 DIGITODD:
   id: 250
   category: digits
@@ -74,6 +84,16 @@ DIGITODD:
   payouttime: end
   pricing_code: DIGITODD
   sentiment: odd
+  base_commission: 0.01  
+DIGITEVEN:
+  id: 260
+  category: digits
+  display_name: even
+  other_side_code: DIGITODD
+  payout_type: binary
+  payouttime: end
+  pricing_code: DIGITEVEN
+  sentiment: even
   base_commission: 0.01
 DIGITOVER:
   id: 270

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -48,7 +48,7 @@ DIGITMATCH:
 DIGITDIFF:
   id: 220
   category: digits
-  display_name: differs
+  display_name: Digit Differs
   other_side_code: DIGITMATCH
   payout_type: binary
   payouttime: end
@@ -68,7 +68,7 @@ DIGITODD:
 DIGITEVEN:
   id: 260
   category: digits
-  display_name: even
+  display_name: Digit Even
   other_side_code: DIGITODD
   payout_type: binary
   payouttime: end
@@ -179,7 +179,7 @@ UPORDOWN:
 TICKHIGH:
   id: 400
   category: highlowticks
-  display_name: high-tick
+  display_name: High-tick
   payout_type: binary
   payouttime: end
   pricing_code: TICKHIGH
@@ -188,7 +188,7 @@ TICKHIGH:
 TICKLOW:
   id: 410
   category: highlowticks
-  display_name: low-tick
+  display_name: Low-tick
   payout_type: binary
   payouttime: end
   pricing_code: TICKLOW

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -185,6 +185,7 @@ TICKHIGH:
   pricing_code: TICKHIGH
   sentiment: high
   base_commission: 0.015
+  has_user_defined_barrier: 0
 TICKLOW:
   id: 410
   category: highlowticks
@@ -193,7 +194,8 @@ TICKLOW:
   payouttime: end
   pricing_code: TICKLOW
   sentiment: low
-  base_commission: 0.015  
+  base_commission: 0.015
+  has_user_defined_barrier: 0
 EXPIRYMISS:
   id: 180
   category: endsinout

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -35,26 +35,6 @@ CALLE:
   payouttime: end
   pricing_code: CALL
   sentiment: up
-DIGITDIFF:
-  id: 220
-  category: digits
-  display_name: Digit Differs
-  other_side_code: DIGITMATCH
-  payout_type: binary
-  payouttime: end
-  pricing_code: DIGITDIFF
-  sentiment: differ
-  base_commission: 0.01
-DIGITEVEN:
-  id: 260
-  category: digits
-  display_name: Digit Even
-  other_side_code: DIGITODD
-  payout_type: binary
-  payouttime: end
-  pricing_code: DIGITEVEN
-  sentiment: even
-  base_commission: 0.01
 DIGITMATCH:
   id: 210
   category: digits

--- a/share/contract_types.yml
+++ b/share/contract_types.yml
@@ -55,26 +55,6 @@ DIGITDIFF:
   pricing_code: DIGITDIFF
   sentiment: differ
   base_commission: 0.01
-TICKHIGH:
-  id: 230
-  category: highlowticks
-  display_name: high-tick
-  other_side_code: TICKLOW
-  payout_type: binary
-  payouttime: end
-  pricing_code: TICKHIGH
-  sentiment: high
-  base_commission: 0.015
-TICKLOW:
-  id: 240
-  category: highlowticks
-  display_name: low-tick
-  other_side_code: TICKHIGH
-  payout_type: binary
-  payouttime: end
-  pricing_code: TICKLOW
-  sentiment: low
-  base_commission: 0.015  
 DIGITODD:
   id: 250
   category: digits
@@ -115,6 +95,26 @@ DIGITUNDER:
   pricing_code: DIGITUNDER
   sentiment: under
   base_commission: 0.01
+TICKHIGH:
+  id: 230
+  category: highlowticks
+  display_name: high-tick
+  other_side_code: TICKLOW
+  payout_type: binary
+  payouttime: end
+  pricing_code: TICKHIGH
+  sentiment: high
+  base_commission: 0.015
+TICKLOW:
+  id: 240
+  category: highlowticks
+  display_name: low-tick
+  other_side_code: TICKHIGH
+  payout_type: binary
+  payouttime: end
+  pricing_code: TICKLOW
+  sentiment: low
+  base_commission: 0.015  
 EXPIRYMISS:
   id: 180
   category: endsinout


### PR DESCRIPTION
Add DIGITHIGH and DIGITLOW to `contract_types.yml`. Rearranged the DIGIT contracts in accordance to id.